### PR TITLE
Allow clients to override default queue config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: node_js
+cache: npm
+node_js:
+  - "stable"
+
+install:
+  - npm install
+  - npm run build
+
+script:
+  - npm run test
+  - npm run coveralls

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Build Status](https://travis-ci.org/nikksan/mq-clients.svg?branch=message-replay)](https://travis-ci.org/nikksan/mq-clients)
+[![Build Status](https://travis-ci.org/LuckboxGG/mq-clients.svg?branch=master)](https://travis-ci.org/LuckboxGG/mq-clients)
 
-[![Coverage Status](https://coveralls.io/repos/github/nikksan/mq-clients/badge.svg?branch=message-replay)](https://coveralls.io/github/nikksan/mq-clients?branch=message-replay)
+[![Coverage Status](https://coveralls.io/repos/github/LuckboxGG/mq-clients/badge.svg?branch=master)](https://coveralls.io/github/LuckboxGG/mq-clients?branch=master)
 
 # Message Broker Clients
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Build Status](https://travis-ci.org/LuckboxGG/mq-clients.svg?branch=master)](https://travis-ci.org/LuckboxGG/mq-clients)
+[![Build Status](https://travis-ci.org/nikksan/mq-clients.svg?branch=message-replay)](https://travis-ci.org/nikksan/mq-clients)
 
-[![Coverage Status](https://coveralls.io/repos/github/LuckboxGG/mq-clients/badge.svg?branch=master)](https://coveralls.io/github/LuckboxGG/mq-clients?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/nikksan/mq-clients/badge.svg?branch=message-replay)](https://coveralls.io/github/nikksan/mq-clients?branch=message-replay)
 
 # Message Broker Clients
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
+[![Build Status](https://travis-ci.org/LuckboxGG/mq-clients.svg?branch=master)](https://travis-ci.org/LuckboxGG/mq-clients)
+
+[![Coverage Status](https://coveralls.io/repos/github/LuckboxGG/mq-clients/badge.svg?branch=master)](https://coveralls.io/github/LuckboxGG/mq-clients?branch=master)
+
 # Message Broker Clients
 
-A collection of message broker implementations. 
+A collection of message broker implementations.
 Each implementation must conform the unified interface, which defines a single client who acts as both publisher and subscriber.
 
 ### Installing

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@luckbox/mq-clients",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1458,6 +1458,55 @@
         }
       }
     },
+    "coveralls": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.1.0.tgz",
+      "integrity": "sha512-sHxOu2ELzW8/NC1UP5XVLbZDzO4S3VxfFye3XYCznopHy02YjNkHcj5bKaVw2O7hVaBdBjEdQGpie4II1mWhuQ==",
+      "dev": true,
+      "requires": {
+        "js-yaml": "^3.13.1",
+        "lcov-parse": "^1.0.0",
+        "log-driver": "^1.2.7",
+        "minimist": "^1.2.5",
+        "request": "^2.88.2"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        },
+        "request": {
+          "version": "2.88.2",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+          "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+          "dev": true,
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.3",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.5.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+          }
+        }
+      }
+    },
     "cross-spawn": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
@@ -3842,6 +3891,12 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
     },
+    "lcov-parse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
+      "integrity": "sha1-6w1GtUER68VhrLTECO+TY73I9+A=",
+      "dev": true
+    },
     "left-pad": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
@@ -4261,6 +4316,12 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
+    },
+    "log-driver": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
+      "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
       "dev": true
     },
     "log-symbols": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luckbox/mq-clients",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev": "tsc-watch --onSuccess \"node ./dist/index.js\"",
     "test": "jest",
     "test:watch": "jest --watchAll --coverage=false",
+    "coveralls": "cat ./coverage/lcov.info | coveralls",
     "lint:staged": "lint-staged",
     "prepublishOnly": "npm run build",
     "precommit": "npm run lint:staged"
@@ -23,6 +24,7 @@
     "@types/lodash": "^4.14.155",
     "@types/p-queue": "^3.2.1",
     "@typescript-eslint/parser": "^2.17.0",
+    "coveralls": "^3.1.0",
     "eslint": "^6.8.0",
     "husky": "^4.0.10",
     "jest": "^24.9.0",

--- a/tests/RabbitMQClient.test.ts
+++ b/tests/RabbitMQClient.test.ts
@@ -19,6 +19,7 @@ import {
   RabbitMQConstructorParams,
   MQConnectionError,
 } from '../src/index';
+import { create } from 'core-js/fn/object';
 
 function createConstructorParams(overrides: DeepPartial<RabbitMQConstructorParams> = {}): RabbitMQConstructorParams {
   const defaultConstructorParams: RabbitMQConstructorParams = {
@@ -187,11 +188,24 @@ describe('RabbitMQClient', () => {
       expect(mockChannel.assertExchange).toHaveBeenCalledWith('my-namespace', 'fanout', { durable: true });
     });
 
-    it('should create an anonymous queue when calling subscribe', async () => {
+    it('should create an anonymous queue when calling subscribe (and no queue config was passed)', async () => {
       await client.connect();
       await client.subscribe('my-namespace', noop);
 
       expect(mockChannel.assertQueue).toHaveBeenCalledWith('', { exclusive: true });
+    });
+
+    it('should create a custom queue when the calling subscribe (and queue config was passed)', async () => {
+      const queueConfiguredClient = new RabbitMQClient(createConstructorParams({
+        queue: {
+          name: 'my-queue',
+          exclusive: false,
+        },
+      }));
+      await queueConfiguredClient.connect();
+      await queueConfiguredClient.subscribe('my-namespace', noop);
+
+      expect(mockChannel.assertQueue).toHaveBeenCalledWith('my-queue', { exclusive: false });
     });
 
     it('should bind the anonymous queue to the exchange using empty routingKey when calling subscribe', async () => {

--- a/tests/RabbitMQClient.test.ts
+++ b/tests/RabbitMQClient.test.ts
@@ -19,7 +19,6 @@ import {
   RabbitMQConstructorParams,
   MQConnectionError,
 } from '../src/index';
-import { create } from 'core-js/fn/object';
 
 function createConstructorParams(overrides: DeepPartial<RabbitMQConstructorParams> = {}): RabbitMQConstructorParams {
   const defaultConstructorParams: RabbitMQConstructorParams = {


### PR DESCRIPTION
In order to allow clients to replay messages in case of downtime, we must create non-exclusive, non-anonymous queues.